### PR TITLE
Remove kirby-language-selector plugin due to incompatibilities with other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,6 @@ Thank you to all plugin's authors and contributors. Make sure to check and suppo
 
 - [kirby-env](https://github.com/beebmx/kirby-env)
 - [kirby-favicon](https://github.com/moritzebeling/kirby-favicon)
-- [kirby-language-selector](https://github.com/junohamburg/kirby-language-selector)
 - [kirby-seo](https://github.com/tobimori/kirby-seo)
 - [kirby-types](https://github.com/lukaskleinschmidt/kirby-types)
 - [kirby-vite](https://github.com/arnoson/kirby-vite)

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "programmatordev/kirby-starter",
-  "description": "A very opinionated Kirby CMS development stack with DDEV, Vite and TailwindCSS",
+  "description": "A very opinionated Kirby CMS development stack with DDEV, Vite, Alpine.js and TailwindCSS",
   "type": "project",
-  "keywords": ["kirby", "kirby-cms", "tailwindcss", "ddev", "vite"],
+  "keywords": ["kirby", "kirby-cms", "tailwindcss", "ddev", "vite", "alpinejs"],
   "authors": [
     {
       "name": "André Pimpão",
@@ -12,11 +12,10 @@
   ],
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "getkirby/cms": "^4.5.0",
+    "getkirby/cms": "^4.6.0",
     "arnoson/kirby-vite": "^5.4",
     "beebmx/kirby-env": "^4.2",
     "tobimori/kirby-seo": "^1.1",
-    "junohamburg/kirby-language-selector": "^1.1",
     "moritzebeling/kirby-favicon": "^1.0"
   },
   "require-dev": {

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   "dependencies": {
     "@unseenco/taxi": "^1.8.0",
     "alpinejs": "^3.14.8",
-    "animated-scroll-to": "^2.3.0",
+    "animated-scroll-to": "^2.3.2",
     "mergician": "^2.0.2",
-    "vanilla-cookieconsent": "^3.0.1"
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
     "fluid-tailwind": "^1.0.4",
     "glob": "^11.0.1",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "vite": "^6.0.9",
+    "vite": "^6.2.0",
     "vite-plugin-kirby": "^5.4.0"
   },
   "scripts": {


### PR DESCRIPTION
Like [kirby-content-translator](https://plugins.getkirby.com/johannschopplich/content-translator) or [kirby-whenquery](https://github.com/rasteiner/k3-whenquery).